### PR TITLE
Configurable screen timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ user=username
 password=password
 clientid=Wink_Relay1
 topic_prefix=Relay1
+screen_timeout=20
 ```
 and put that in /sdcard/mqtt.ini on the Wink Relay.
 
-Host: Hostname or IP address of the MQTT broker
-Port: Port of the MQTT broker
-User: Username used to authenticate to the MQTT broker (optional)
-Password: Password used to authenticate to the MQTT broker (optional)
-clientid: Client ID passed to the broker (optional - Wink_Relay if not provided)
-topic_prefix: Prefix to the topics presented by the device (optional - Relay if not provided)
+host: Hostname or IP address of the MQTT broker  
+port: Port of the MQTT broker  
+user: Username used to authenticate to the MQTT broker (optional)  
+password: Password used to authenticate to the MQTT broker (optional)  
+clientid: Client ID passed to the broker (optional - Wink_Relay if not provided)  
+topic_prefix: Prefix to the topics presented by the device (optional - Relay if not provided)  
+screen_timeout: Time in seconds until the screen turns off after a touch or proximity detection (optional - 10s if not provided)
 
 Finally, reset your Relay.
 


### PR DESCRIPTION
Added code to wink-handler.c that allows the user to specify the screen timeout time in mqtt.ini in the optional parameter "screen_timeout". Defaults to 10s if screen_timeout is not provided. Also updated README.md with instructions for the new parameter.

I added this code as I found that 10s was a little too quick given that the proximity detection appears limited to about 5cm in front of the device and doesn't appear to trigger if you are standing away from the Wink Relay but still looking at the screen. 

I think that the Wink Relay also has a motion sensor which may be more useful for the purpose of controlling screen on/off but I've yet to find it in /sys (there appears to be a light sensor in /sys/class/i2c-dev/i2c-2/device/2-0044/ but I don't think that would be useful here). If the motion sensor is found it could also be used to send a mqtt message for the purpose of controlling lights automatically when someone walks past the Wink Relay, so could be useful in two ways.

I've attached a compiled version of wink-handler that includes this pull request if you are interested in adding it to this repo as a release.

[wink-handler.zip](https://github.com/mjg59/wink-relay-handler/files/1459086/wink-handler.zip)

