### PR TITLE
Bugfix: don't define last_input again in main()

### DIFF
--- a/wink-handler.c
+++ b/wink-handler.c
@@ -189,7 +189,6 @@ int main() {
 	bool motion = 0;
 	char urelaystate=' ';
 	char lrelaystate=' ';
-	int last_input = time(NULL);
 	int last_motion = time(NULL);
 	struct input_event event;
 	unsigned char buf[100], readbuf[100];


### PR DESCRIPTION
last_input is defined globally so that it can be updated by the handle_screen function; last_input was being defined again in main() which led to the MQTT screen turn on functionality not working properly; this must have snuck in while merging my pull requests.